### PR TITLE
making changes to  allowing requiring submodule

### DIFF
--- a/src/templates.js
+++ b/src/templates.js
@@ -45,13 +45,25 @@ function print() { __p += __j.call(arguments, '') }
 with (obj) {
 
  if(data.deps && data.deps.length){ ;
-__p += '\r\n';
+__p += '\r\n    ';
  for (var i = 0; i < data.deps.length; i += 1) { ;
-__p += '\r\nvar ' +
+__p += '\r\n        ';
+ if(data.deps[i].indexOf(".")>0) { ;
+__p += '\r\n            var ' +
+((__t = ( data.deps[i].split(".")[0] )) == null ? '' : __t) +
+' = require("' +
+((__t = ( data.deps[i].split(".")[0] )) == null ? '' : __t) +
+'").' +
+((__t = ( data.deps[i].split(".")[1] )) == null ? '' : __t) +
+';\r\n        ';
+ } else  { ;
+__p += '\r\n            var ' +
 ((__t = ( data.args && data.args.length ? data.args [i] : data.deps[i])) == null ? '' : __t) +
 ' = require("' +
 ((__t = ( data.deps[i] )) == null ? '' : __t) +
-'");\r\n';
+'");\r\n        ';
+ } ;
+__p += '\r\n    ';
  } ;
 __p += '\r\n';
  } ;

--- a/src/templates/commonjs.jst
+++ b/src/templates/commonjs.jst
@@ -1,7 +1,11 @@
 <% if(data.deps && data.deps.length){ %>
-<% for (var i = 0; i < data.deps.length; i += 1) { %>
-var <%= data.args && data.args.length ? data.args [i] : data.deps[i]%> = require("<%= data.deps[i] %>");
-<% } %>
+    <% for (var i = 0; i < data.deps.length; i += 1) { %>
+        <% if(data.deps[i].indexOf(".")>0) { %>
+            var <%= data.deps[i].split(".")[0] %> = require("<%= data.deps[i].split(".")[0] %>").<%= data.deps[i].split(".")[1] %>;
+        <% } else  { %>
+            var <%= data.args && data.args.length ? data.args [i] : data.deps[i]%> = require("<%= data.deps[i] %>");
+        <% } %>
+    <% } %>
 <% } %>
 
 <% if(data.exports){ %>

--- a/tests/commonjs.spec.js
+++ b/tests/commonjs.spec.js
@@ -19,7 +19,14 @@ describe('commonjs', function () {
             for (var i = 0; i < options.deps.length; i += 1) {
                 var dep = options.deps[i];
                 var arg = options.args[i];
-                result += 'var ' + (arg ? arg : dep) + ' = require("' + dep + '");';
+                if(dep.indexOf('.') > 0) {
+                    var arr = dep.split(".");
+                    var module = arr[0];
+                    var subModule = arr[1];
+                    result += 'var ' + (module) + ' = require("' + module + '").' + subModule + ';';
+                }else {
+                    result += 'var ' + (arg ? arg : dep) + ' = require("' + dep + '");';
+                }
             }
         }
 
@@ -58,7 +65,7 @@ describe('commonjs', function () {
         var original = '',
             options = {
                 type: 'commonjs',
-                deps: ['dep1', 'dep2']
+                deps: ['dep1', 'dep2', 'dep3.dep4']
             };
 
         gulp.src(helpers.getFixtures('./plain-script-3.js'))


### PR DESCRIPTION
I had a requirement to do something like `var jade = require('jade').runtime` in my compiled jade templates. 
So, idea is when passing options to wrapper , it would be nice if we could do it like following
```
wrapper({
            type: 'commonjs',
            deps: ['jade.runtime']
        })
```